### PR TITLE
Feature v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # Plugin ocr_translate_hugging_face
 
 This is a plugin for the [ocr_translate](https://github.com/Crivella/ocr_translate).
-Plugins to enable usage of HuggingFace Models in ocr_translate
+Plugins to enable usage of [HuggingFace Models](https://huggingface.co/) in ocr_translate
 
 ## Usage
+
+For versions of the server `<v0.6`
 
 - Install this by running `pip install ocr_translate-hugging_face`
 - Add `ocr_translate_hugging_face` to your `INSTALLED_APPS` in `settings.py`
 - Run the server with `AUTOCREATE_VALIDATED_MODELS` once
+
+For versions of the server `>=0.6`
+
+- Install through the server plugin manager

--- a/ocr_translate_hugging_face/__init__.py
+++ b/ocr_translate_hugging_face/__init__.py
@@ -18,7 +18,7 @@
 ###################################################################################
 """Plugins to enable usage of HuggingFace Models in ocr_translate"""
 
-__version__ = '0.2.1'
+__version__ = '0.3.0'
 
 khawhite_ocr_model_data = {
     'name': 'kha-white/manga-ocr-base',

--- a/ocr_translate_hugging_face/plugin/__init__.py
+++ b/ocr_translate_hugging_face/plugin/__init__.py
@@ -1,0 +1,26 @@
+###################################################################################
+# ocr_translate-hugging_face - a plugin for ocr_translate                         #
+# Copyright (C) 2023-present Davide Grassano                                      #
+#                                                                                 #
+# This program is free software: you can redistribute it and/or modify            #
+# it under the terms of the GNU General Public License as published by            #
+# the Free Software Foundation, either version 3 of the License.                  #
+#                                                                                 #
+# This program is distributed in the hope that it will be useful,                 #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of                  #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   #
+# GNU General Public License for more details.                                    #
+#                                                                                 #
+# You should have received a copy of the GNU General Public License               #
+# along with this program.  If not, see {http://www.gnu.org/licenses/}.           #
+#                                                                                 #
+# Home: https://github.com/Crivella/ocr_translate-hugging_face                    #
+###################################################################################
+"""Collection of importable plugins."""
+from .seq2seq import HugginfaceSeq2SeqModel
+from .ved import HugginfaceVEDModel
+
+__all__ = (
+    'HugginfaceSeq2SeqModel',
+    'HugginfaceVEDModel',
+)

--- a/ocr_translate_hugging_face/plugin/utils.py
+++ b/ocr_translate_hugging_face/plugin/utils.py
@@ -92,5 +92,11 @@ class EnvMixin():
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.dev = os.environ.get('DEVICE', 'cpu')
-        self.root = Path(os.environ.get('TRANSFORMERS_CACHE', '.'))
-        logger.debug(f'Cache dir: {self.root}')
+        if 'TRANSFORMERS_CACHE' in os.environ:
+            self.root = Path(os.environ.get('TRANSFORMERS_CACHE'))
+        elif 'OCT_BASE_DIR' in os.environ:
+            self.root = Path(os.environ.get('OCT_BASE_DIR')) / 'models' / 'huggingface'
+        else:
+            raise ValueError('No TRANSFORMERS_CACHE or OCT_BASE_DIR environment variable found.')
+        self.root.mkdir(parents=True, exist_ok=True)
+        logger.debug(f'HuggingFace model dir: {self.root}')

--- a/ocr_translate_hugging_face/plugin/utils.py
+++ b/ocr_translate_hugging_face/plugin/utils.py
@@ -1,0 +1,96 @@
+###################################################################################
+# ocr_translate-hugging_face - a plugin for ocr_translate                         #
+# Copyright (C) 2023-present Davide Grassano                                      #
+#                                                                                 #
+# This program is free software: you can redistribute it and/or modify            #
+# it under the terms of the GNU General Public License as published by            #
+# the Free Software Foundation, either version 3 of the License.                  #
+#                                                                                 #
+# This program is distributed in the hope that it will be useful,                 #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of                  #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   #
+# GNU General Public License for more details.                                    #
+#                                                                                 #
+# You should have received a copy of the GNU General Public License               #
+# along with this program.  If not, see {http://www.gnu.org/licenses/}.           #
+#                                                                                 #
+# Home: https://github.com/Crivella/ocr_translate-hugging_face                    #
+###################################################################################
+"""Generic functions to work with HuggingFace's Classes."""
+
+import logging
+import os
+from pathlib import Path
+
+from transformers import (AutoImageProcessor, AutoModel, AutoModelForSeq2SeqLM,
+                          AutoModelForZeroShotImageClassification,
+                          AutoTokenizer, VisionEncoderDecoderModel)
+
+logger = logging.getLogger('plugin')
+
+class Loaders():
+    """Generic functions to load HuggingFace's Classes."""
+    accept_device = ['ved_model', 'seq2seq', 'model']
+
+    mapping = {
+        'tokenizer': AutoTokenizer,
+        'ved_model': VisionEncoderDecoderModel,
+        'model': AutoModel,
+        'image_processor': AutoImageProcessor,
+        'seq2seq': AutoModelForSeq2SeqLM,
+        'zsic_model': AutoModelForZeroShotImageClassification
+    }
+
+    @staticmethod
+    def _load(loader, model_id: str, root: Path):
+        """Use the specified loader to load a transformers specific Class."""
+        try:
+            mid = root / model_id
+            logger.debug(f'Attempt loading from store: "{loader}" "{mid}"')
+            res = loader.from_pretrained(mid)
+        except Exception:
+            # Needed to catch some weird exception from transformers
+            # eg: huggingface_hub.utils._validators.HFValidationError: Repo id must use alphanumeric chars or
+            # '-', '_', '.', '--' and '..' are forbidden, '-' and '.'
+            # cannot start or end the name, max length is 96: ...
+            logger.debug(f'Attempt loading from cache: "{loader}" "{model_id}" "{root}"')
+            res = loader.from_pretrained(model_id, cache_dir=root)
+        return res
+
+    @staticmethod
+    def load(model_id: str, request: list[str], root: Path, dev: str = 'cpu') -> list:
+        """Load the requested HuggingFace's Classes for the model into the memory of the globally specified device.
+
+        Args:
+            model_id (str): The HuggingFace model id to load, or a path to a local model.
+            request (list[str]): A list of HuggingFace's Classes to load.
+            root (Path): The root path to use for the cache.
+
+        Raises:
+            ValueError: If the model_id is not found or if the requested Class is not supported.
+
+        Returns:
+            _type_: A list of the requested Classes.
+        """    """"""
+        res = {}
+        for r in request:
+            if r not in Loaders.mapping:
+                raise ValueError(f'Unknown request: {r}')
+            cls = Loaders._load(Loaders.mapping[r], model_id, root)
+            if cls is None:
+                raise ValueError(f'Could not load model: {model_id}')
+
+            if r in Loaders.accept_device:
+                cls = cls.to(dev)
+
+            res[r] = cls
+
+        return res
+
+class EnvMixin():
+    """Mixin to allow usage of environment variables."""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dev = os.environ.get('DEVICE', 'cpu')
+        self.root = Path(os.environ.get('TRANSFORMERS_CACHE', '.'))
+        logger.debug(f'Cache dir: {self.root}')

--- a/ocr_translate_hugging_face/plugin/ved.py
+++ b/ocr_translate_hugging_face/plugin/ved.py
@@ -43,11 +43,19 @@ class HugginfaceVEDModel(m.OCRModel, EnvMixin):
         """Load the model into memory."""
         logger.info(f'Loading OCR VED model: {self.name}')
         res = Loaders.load(
-            self.name, request=['ved_model', 'tokenizer', 'image_processor'],
+            self.name, request=['ved_model'],
             root=self.root, dev=self.dev
             )
         self.model = res['ved_model']
+        res = Loaders.load(
+            self.tokenizer_name or self.name, request=['tokenizer'],
+            root=self.root, dev=self.dev
+            )
         self.tokenizer = res['tokenizer']
+        res = Loaders.load(
+            self.processor_name or self.name, request=['image_processor'],
+            root=self.root, dev=self.dev
+            )
         self.image_processor = res['image_processor']
 
     def unload(self) -> None:

--- a/ocr_translate_hugging_face/plugin/ved.py
+++ b/ocr_translate_hugging_face/plugin/ved.py
@@ -1,0 +1,101 @@
+###################################################################################
+# ocr_translate-hugging_face - a plugin for ocr_translate                         #
+# Copyright (C) 2023-present Davide Grassano                                      #
+#                                                                                 #
+# This program is free software: you can redistribute it and/or modify            #
+# it under the terms of the GNU General Public License as published by            #
+# the Free Software Foundation, either version 3 of the License.                  #
+#                                                                                 #
+# This program is distributed in the hope that it will be useful,                 #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of                  #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                   #
+# GNU General Public License for more details.                                    #
+#                                                                                 #
+# You should have received a copy of the GNU General Public License               #
+# along with this program.  If not, see {http://www.gnu.org/licenses/}.           #
+#                                                                                 #
+# Home: https://github.com/Crivella/ocr_translate-hugging_face                    #
+###################################################################################
+"""Class to enable hugginface VisionEncoderDecoder models."""
+import logging
+
+import torch
+from ocr_translate import models as m
+from PIL import Image
+
+from .utils import EnvMixin, Loaders
+
+logger = logging.getLogger('plugin')
+
+class HugginfaceVEDModel(m.OCRModel, EnvMixin):
+    """OCRtranslate plugin to allow loading of hugginface VisionEncoderDecoder model as text OCR."""
+    class Meta: # pylint: disable=missing-class-docstring
+        proxy = True
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the model."""
+        super().__init__(*args, **kwargs)
+        self.tokenizer = None
+        self.model = None
+        self.image_processor = None
+
+    def load(self):
+        """Load the model into memory."""
+        logger.info(f'Loading OCR VED model: {self.name}')
+        res = Loaders.load(
+            self.name, request=['ved_model', 'tokenizer', 'image_processor'],
+            root=self.root, dev=self.dev
+            )
+        self.model = res['ved_model']
+        self.tokenizer = res['tokenizer']
+        self.image_processor = res['image_processor']
+
+    def unload(self) -> None:
+        """Unload the model from memory."""
+        if self.model is not None:
+            del self.model
+            self.model = None
+        if self.tokenizer is not None:
+            del self.tokenizer
+            self.tokenizer = None
+        if self.image_processor is not None:
+            del self.image_processor
+            self.image_processor = None
+
+        if self.dev == 'cuda':
+            torch.cuda.empty_cache()
+
+    def _ocr(
+            self,
+            img: Image.Image, lang: str = None, options: dict = None
+            ) -> str:
+        """Perform OCR on an image.
+
+        Args:
+            img (Image.Image):  A Pillow image on which to perform OCR.
+            lang (str, optional): The language to use for OCR. (Not every model will use this)
+            bbox (tuple[int, int, int, int], optional): The bounding box of the text on the image in lbrt format.
+            options (dict, optional): A dictionary of options to pass to the OCR model.
+
+        Raises:
+            TypeError: If img is not a Pillow image.
+
+        Returns:
+            str: The text extracted from the image.
+        """
+        if self.model is None or self.tokenizer is None or self.image_processor is None:
+            raise RuntimeError('Model not loaded')
+
+        if options is None:
+            options = {}
+
+        pixel_values = self.image_processor(img, return_tensors='pt').pixel_values
+        if self.dev == 'cuda':
+            pixel_values = pixel_values.cuda()
+        generated_ids = self.model.generate(pixel_values)
+        generated_text = self.tokenizer.batch_decode(generated_ids, skip_special_tokens=True)[0]
+
+        if self.dev == 'cuda':
+            torch.cuda.empty_cache()
+
+        return generated_text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ dependencies = [
     "django-ocr_translate>=0.5.0,<1.0",
     "opencv-python-headless~=4.8.0.74",
 
-    "torch~=2.0.1",
-    "torchvision~=0.15.2",
+    "torch~=2.2.1",
+    "torchvision~=0.17.1",
 
     "transformers~=4.30.2",
     "protobuf~=3.20.0", # microsoft/trocr-small-printed: XLMRobertaConverter requires the protobuf library

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ disable = [
     "global-statement",
     "broad-exception-caught",
     "too-few-public-methods",
+    "duplicate-code"
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ from ocr_translate import models as m
 from PIL import Image
 
 from ocr_translate_hugging_face import plugin as hugginface
+from ocr_translate_hugging_face.plugin.utils import EnvMixin, Loaders
 
 strings = [
     'This is a test string.',
@@ -112,7 +113,7 @@ def mock_loader(monkeypatch):
                     raise FileNotFoundError('Not in dir')
             elif isinstance(model_id, str):
                 if cache_dir is None:
-                    cache_dir = hugginface.EnvMixin().root
+                    cache_dir = EnvMixin().root
                 if not (cache_dir / f'models--{model_id.replace("/", "--")}').is_dir():
                     raise FileNotFoundError('Not in cache')
 
@@ -122,7 +123,7 @@ def mock_loader(monkeypatch):
                     pass
             return A()
 
-    monkeypatch.setattr(hugginface.Loaders, 'mapping', {
+    monkeypatch.setattr(Loaders, 'mapping', {
         'tokenizer': Loader(),
         'seq2seq': Loader(),
         'model': Loader(),


### PR DESCRIPTION
# Changes

- Changed DEUFAULT dir for models to be based on OCT_BASE_DIR
- Added possibility to have ocr models with tokenizer and processor from other models
- Changed README to reflect server `v0.6.0`

Requires server v0.6.0 to be available on PyPi to pass test suite

- https://github.com/Crivella/ocr_translate/pull/33